### PR TITLE
Fix bug in Menu SelectedItem property and AddItem

### DIFF
--- a/lib/src/Main/Menu.cs
+++ b/lib/src/Main/Menu.cs
@@ -101,7 +101,7 @@ namespace Console.Menus.lib.src.Main
         public int SelectedIndex { get; private set; } = -1;
 
         /// <inheritdoc />
-        public IMenuItem? SelectedItem => SelectedIndex < 0 || SelectedIndex >= _subItems.Count ? _subItems[SelectedIndex] : null;
+        public IMenuItem? SelectedItem => SelectedIndex < 0 || SelectedIndex >= _subItems.Count ? null : _subItems[SelectedIndex];
         /// <inheritdoc />
         public event EventHandler<PerformActionEventArgs>? ActionPerformed;
         /// <inheritdoc />
@@ -208,7 +208,7 @@ namespace Console.Menus.lib.src.Main
         
         public bool AddItem(string caption = "<insert caption>", EventHandler<PerformActionEventArgs> actionToPerform = default, object? tag = default)
         {
-            var menuItem = new MenuItem(caption, actionToPerform) { Tag = null };
+            var menuItem = new MenuItem(caption, actionToPerform) { Tag = tag };
             return AddItem(menuItem);
         }
 


### PR DESCRIPTION
## Summary
- fix SelectedItem property logic so it does not access an invalid index
- ensure tag parameter is assigned in AddItem overload

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684179ea3c94832e87acf368ba8354b9